### PR TITLE
Simplify FASTA parsing

### DIFF
--- a/src/main/scala/fasta.scala
+++ b/src/main/scala/fasta.scala
@@ -127,115 +127,45 @@ case object fasta {
   implicit lazy val sequenceParser =
     new DenotationParser(sequence, sequence.label)({ v: String => Some(FastaSequence(v)) })
 
-  /*
-    This method returns an iterator over `Map[String, String]` which can be directly used by `FASTA.parse`.
+  /* Note, all we only use `next`, `hasNext` and `head` method here, so the `lines` iterator can be used after calling any of these extension methods and can be considered as the parsing "remainder" (i.e. unparsed part) */
+  implicit class BufferedIteratorFASTAOps(val lines: BufferedIterator[String]) extends AnyVal {
 
-    **NOTE** the `lines` iterator should *not* be used after calling `parseFromLines` on it.
-  */
-  final def parseMap(lines: Iterator[String]): Iterator[Map[String, String]] = new Iterator[Map[String, String]] {
-
-    // NOTE see https://groups.google.com/forum/#!topic/scala-user/BPjFbrglfMs for why this is that ugly
-
-    // Iterator state
-    var currentHeader : String = ""
-    var nextHeader    : String = ""
-    // this stores the current "next" map
-    var currentMap: Option[Map[String, String]] = None
-    // if you do hasNext twice, it won't call evalNext again
-    var hasBeenChecked: Boolean = false
-    var isFirst       : Boolean = true
-
-    private def evalNext: Option[Map[String, String]] = {
-
-      val currentSequence = new StringBuilder
-
-      var foundHeader = false
-      // first time: find a header, and accumulate seq til you find another header
-      if (isFirst) {
-
-        while (lines.hasNext && nextHeader.isEmpty) {
-
-          val currentLine = lines.next
-
-          if (header is currentLine) {
-
-            if(!foundHeader) {
-              currentHeader = currentLine
-              foundHeader   = true
-            }
-            else {
-              nextHeader = currentLine
-            }
-          }
-          else if (currentHeader.nonEmpty) {
-            currentSequence append currentLine
-          }
-        }
-
-        isFirst = false
-      }
-      else if(nextHeader.nonEmpty) {
-
-        currentHeader = nextHeader
-        nextHeader    = ""
-        foundHeader   = false
-
-        while (lines.hasNext && !foundHeader) {
-
-          val currentLine = lines.next
-
-          if (header is currentLine) {
-
-            foundHeader = true
-            nextHeader  = currentLine
-          }
-          else {
-            currentSequence append currentLine
-          }
-        }
-      }
-
-      if (currentHeader.isEmpty) {
-        None
-      }
-      else {
-        val tmpMap = Some(
-          collection.immutable.HashMap(
-            header.label   -> currentHeader,
-            sequence.label -> currentSequence.toString
-          )
-        )
-        // THIS IS IMPORTANT
-        currentHeader = ""
-        tmpMap
-      }
+    /* Similar to `takeWhile`, but the iterator **can be reused** after */
+    private def cutUntil(condition: String => Boolean): Seq[String] = {
+      if (lines.hasNext && !condition(lines.head))
+        lines.next() +: cutUntil(condition)
+      else Seq()
     }
 
-    // now the Iterator methods:
-    def hasNext = if(hasBeenChecked) {
-      currentMap.nonEmpty
-    }
-    else {
-      currentMap = evalNext;
-      currentMap.nonEmpty
+    /* You can use this method when you want to parse just one FASTA value and continue using the `lines` iterator as _lines_ */
+    def parseOneFasta(): Either[ParseDenotationsError, FASTA.Value] = {
+      val hdr: String = lines.next()
+      val seq: String = cutUntil(fasta.header.is).mkString
+
+      val valueMap = Map[String, String](
+          header.label -> hdr,
+        sequence.label -> seq
+      )
+
+      FASTA parse valueMap
     }
 
-    def next: Map[String, String] = {
+    /* Use this method to parse all FASTA values from the `lines` iterator (with possible errors) */
+    def parseFasta():
+        Iterator[ Either[ParseDenotationsError, FASTA.Value] ] =
+    new Iterator[ Either[ParseDenotationsError, FASTA.Value] ] {
 
-      hasBeenChecked = false;
-      val tmpMap = currentMap.get
-      currentMap = None
-      tmpMap
+      /* If there is one more header, there is one more FASTA value (even if the sequence is empty) */
+      def hasNext: Boolean = lines.hasNext && fasta.header.is(lines.head)
+
+      def next(): Either[ParseDenotationsError, FASTA.Value] = parseOneFasta()
+    }
+
+    /* This is the same as `parseFasta` dropping all erroneous FASTAs and skipping anything before the first FASTA value */
+    def parseFastaDropErrors(skipCrap: Boolean = true): Iterator[FASTA.Value] = {
+      if (skipCrap) cutUntil(fasta.header.is)
+      parseFasta() collect { case Right(fa) => fa }
     }
   }
 
-  /*
-    Exactly the same as `parseMapFromLines`, but returning either a parsing error or a `FASTA` denotation.
-  */
-  // TODO update after gettting good Raw in cosas records
-  final def parseFasta(lines: Iterator[String]): Iterator[ Either[ParseDenotationsError, FASTA.Value] ] =
-    parseMap(lines) map { strMap => FASTA parse strMap }
-
-  final def parseFastaDropErrors(lines: Iterator[String]): Iterator[FASTA.Value] =
-    parseFasta(lines) collect { case Right(fa) => fa }
 }

--- a/src/test/scala/FastaTests.scala
+++ b/src/test/scala/FastaTests.scala
@@ -102,31 +102,9 @@ class FastaTests extends FunSuite {
 
     // WARNING this will leak file descriptors
     val lines   = Files.lines(fastaFile.toPath).iterator
-    val asFasta = fasta.parseFastaDropErrors(lines)
+    val asFasta = lines.buffered.parseFastaDropErrors()
 
     asFasta appendTo parsedFile
-  }
-
-  test("raw parsing from iterator") {
-
-    val fastaFile   = new File("test.fasta")
-    val parsedFile  = new File("parsed-raw.fasta")
-    Files.deleteIfExists(parsedFile.toPath)
-
-    // WARNING this will leak file descriptors
-    val lines  = Files.lines(fastaFile.toPath).iterator
-    val asMaps = fasta.parseMap(lines)
-
-    def append(f: File, str: String) = {
-      Files.write(f.toPath, Seq(str), StandardOpenOption.CREATE, StandardOpenOption.APPEND)
-    }
-
-    asMaps.foreach {
-      map => {
-        append(parsedFile, s">${map("header")}")
-        append(parsedFile, map("sequence").grouped(70).mkString("\n"))
-      }
-    }
   }
 
   test("FASTA lines parsing") {
@@ -155,37 +133,37 @@ class FastaTests extends FunSuite {
     )
 
     assert {
-      fasta.parseFastaDropErrors( (crap ++ fasta1.lines).iterator ).toList ==
+      (crap ++ fasta1.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(fasta1)
     }
 
     assert {
-      fasta.parseFastaDropErrors( (crap ++ emptyFasta.lines ++ fasta1.lines).iterator ).toList ==
+      (crap ++ emptyFasta.lines ++ fasta1.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(emptyFasta, fasta1)
     }
 
     assert {
-      fasta.parseFastaDropErrors( emptyFasta.lines.iterator ).toList ==
+      emptyFasta.lines.iterator.buffered.parseFastaDropErrors().toList ==
         List(emptyFasta)
     }
 
     assert {
-      fasta.parseFastaDropErrors( (fasta1.lines ++ emptyFasta.lines).iterator ).toList ==
+      (fasta1.lines ++ emptyFasta.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(fasta1, emptyFasta)
     }
 
     assert {
-      fasta.parseFastaDropErrors(List(fasta1,fasta2).flatMap(_.lines).iterator).toList ==
+      List(fasta1,fasta2).flatMap(_.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(fasta1,fasta2)
     }
 
     assert {
-      fasta.parseFastaDropErrors(List(emptyFasta,fasta2,fasta1,fasta2,fasta2,fasta1).flatMap(_.lines).iterator).toList ==
+      List(emptyFasta,fasta2,fasta1,fasta2,fasta2,fasta1).flatMap(_.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(emptyFasta,fasta2,fasta1,fasta2,fasta2,fasta1)
     }
 
     assert {
-      fasta.parseFastaDropErrors(List(emptyFasta,emptyFasta,fasta2,emptyFasta,fasta1,fasta2,fasta2,fasta1,emptyFasta).flatMap(_.lines).iterator).toList ==
+      List(emptyFasta,emptyFasta,fasta2,emptyFasta,fasta1,fasta2,fasta2,fasta1,emptyFasta).flatMap(_.lines).iterator.buffered.parseFastaDropErrors().toList ==
         List(emptyFasta,emptyFasta,fasta2,emptyFasta,fasta1,fasta2,fasta2,fasta1,emptyFasta)
     }
   }


### PR DESCRIPTION
I had a very similar implementation in https://github.com/era7bio/loopg/pull/2, so I just adapted it here. It is based on the same idea as https://github.com/ohnosequences/db.rna16s/pull/47: using `BufferedIterator` for simple look-ahead.

The old implementation is just too hard to maintain, it's even hard to read. The only good thing about it was that it worked (as a result of lot of suffering).