### PR TITLE
Unify FASTA/FASTQ parsing API

### DIFF
--- a/src/main/scala/fastq.scala
+++ b/src/main/scala/fastq.scala
@@ -19,8 +19,7 @@ case object fastq {
     plus      :×:
     quality   :×:
     |[AnyType]
-  )
-  {
+  ) {
 
     type RealRaw =
       (id.type        := id.Raw)        ::
@@ -78,11 +77,9 @@ case object fastq {
   // the value here is assumed (and guaranteed) to be '@'-free
   final class FastqId private[fastarious] (val value: String) extends AnyVal {
 
-    def toFastaHeader: FastaHeader =
-      new FastaHeader(value)
+    def toFastaHeader: FastaHeader = new FastaHeader(value)
 
-    def asString: String =
-      s"${id.start}${value}"
+    def asString: String = s"${id.start}${value}"
   }
 
   case object FastqSequence {
@@ -107,8 +104,7 @@ case object fastq {
   // the value here is assumed (and guaranteed) to be '@'-free
   final class FastqPlus private[fastarious] (val value: String) extends AnyVal {
 
-    def asString: String =
-      s"${plus.start}${value}"
+    def asString: String = s"${plus.start}${value}"
   }
 
   case object FastqQuality {
@@ -124,39 +120,37 @@ case object fastq {
   case class FASTQOps(val seq: FASTQ.Value) extends AnyVal {
 
     def toFASTA: FASTA.Value = FASTA(
-      fasta.header( seq.getV(id).toFastaHeader )                   ::
-      fasta.sequence( FastaSequence(seq.getV(sequence).asString) ) :: *[AnyDenotation]
+      fasta.header( seq.getV(id).toFastaHeader ) ::
+      fasta.sequence( FastaSequence(seq.getV(sequence).asString) ) ::
+      *[AnyDenotation]
     )
 
-    def asString: String =
-      (
-        seq.getV(id).asString       ::
-        seq.getV(sequence).asString ::
-        seq.getV(plus).asString     ::
-        seq.getV(quality).asString  ::
-        Nil
-      ).mkString("\n")
+    def asString: String = Seq(
+      seq.getV(id).asString,
+      seq.getV(sequence).asString,
+      seq.getV(plus).asString,
+      seq.getV(quality).asString
+    ).mkString("\n")
   }
 
-  def parseMap(lines: Iterator[String]): Iterator[Map[String, String]] = {
+  implicit class IteratorFASTQOps(val lines: Iterator[String]) extends AnyVal {
 
-    // NOTE much unsafe, should check for id and qual chars etc
-    lines.grouped(4) map {
-      quartet => {
-        Map(
-          id.label       -> quartet(0),
-          sequence.label -> quartet(1),
-          plus.label     -> quartet(2),
-          quality.label  -> quartet(3)
-        )
-      }
+    def parseMap(): Iterator[Map[String, String]] = {
+
+      // NOTE much unsafe, should check for id and qual chars etc
+      lines.grouped(4) map { quartet => Map(
+        id.label       -> quartet(0),
+        sequence.label -> quartet(1),
+        plus.label     -> quartet(2),
+        quality.label  -> quartet(3)
+      )}
     }
+
+    def parseFastq(): Iterator[ Either[ParseDenotationsError, FASTQ.Value] ] =
+      parseMap map { strMap => FASTQ parse strMap }
+
+    def parseFastqDropErrors(): Iterator[FASTQ.Value] =
+      parseFastq collect { case Right(fq) => fq }
   }
-
-  def parseFastq(lines: Iterator[String]): Iterator[ Either[ParseDenotationsError, FASTQ.Value] ] =
-    parseMap(lines) map { strMap => FASTQ parse strMap }
-
-  def parseFastqDropErrors(lines: Iterator[String]): Iterator[FASTQ.Value] =
-    parseFastq(lines) collect { case Right(fq) => fq }
 
 }

--- a/src/test/scala/FastqTests.scala
+++ b/src/test/scala/FastqTests.scala
@@ -32,8 +32,8 @@ class FastqTests extends FunSuite {
     import java.nio.file._
     import scala.collection.JavaConversions._
     // WARNING this will leak file descriptors
-    val lines = Files.lines(input.toPath).iterator
-    val buh = parseFastq(lines)
+    val lines: Iterator[String] = Files.lines(input.toPath).iterator
+    val buh = lines.parseFastq()
   }
 
   test("generate fastq file") {
@@ -68,10 +68,9 @@ class FastqTests extends FunSuite {
     import scala.collection.JavaConversions._
 
     // WARNING this will leak file descriptors
-    val lines   = Files.lines(fastaFile.toPath).iterator
-    val asFastq = fastq.parseFastqDropErrors(lines)
+    val lines: Iterator[String] = Files.lines(fastaFile.toPath).iterator
 
-    asFastq appendTo parsedFile
+    lines.parseFastqDropErrors() appendTo parsedFile
   }
 
 


### PR DESCRIPTION
I changed FASTA parsing API in the last release, but forgot to change FASTQ, so they look different now.