### PR TITLE
Drop 16+MB of the Jar ballast

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
 name          := "fastarious"
 organization  := "ohnosequences"
 description   := "FASTQ and FASTA APIs"
-
 bucketSuffix  := "era7.com"
 
+crossScalaVersions := Seq("2.11.11", "2.12.3")
+scalaVersion := crossScalaVersions.value.max
+
 libraryDependencies ++= Seq(
-  "ohnosequences"   %% "cosas" % "0.8.0",
-  "org.spire-math"  %% "spire" % "0.13.0"
+  "ohnosequences" %% "cosas" % "0.9.0"
 )
 
 // NOTE should be reestablished

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 resolvers ++= Seq(
   "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com",
-  "repo.jenkins-ci.org" at "https://repo.jenkins-ci.org/public"
+  "repo.jenkins-ci.org" at "https://repo.jenkins-ci.org/public",
+  Resolver.jcenterRepo
 )
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0-RC5")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.8.0")

--- a/src/main/scala/quality.scala
+++ b/src/main/scala/quality.scala
@@ -1,7 +1,6 @@
 package ohnosequences.fastarious
 
 import Quality._
-import spire.implicits._
 
 /*
   ## Quality
@@ -102,9 +101,7 @@ case object Quality {
 
   final
   def scoreFrom(errP: ErrorP): Score =
-    // ((-10) * errP.log(10)).round().intValue
-    Math.round((-10:Double) * errP.log(10)).toInt
-
+    Math.round( -10 * Math.log10(errP) ).toInt
 
   final
   def errorProbability(n: Score): ErrorP =
@@ -112,9 +109,7 @@ case object Quality {
 
   private final
   def errorProbabilityImpl(n: Score): ErrorP =
-    // BigDecimal(10) fpow ( - (BigDecimal(n) / 10) )
-    (10:Double) fpow ( - ((n:Double) / 10) )
-
+    Math.pow(10, -(n: Double) / 10)
 
   final
   def successProbability(n: Score): Prob =

--- a/src/main/scala/quality.scala
+++ b/src/main/scala/quality.scala
@@ -101,7 +101,7 @@ case object Quality {
 
   final
   def scoreFrom(errP: ErrorP): Score =
-    Math.round( -10 * Math.log10(errP) ).toInt
+    Math.round( -10D * Math.log10(errP) ).toInt
 
   final
   def errorProbability(n: Score): ErrorP =
@@ -109,7 +109,7 @@ case object Quality {
 
   private final
   def errorProbabilityImpl(n: Score): ErrorP =
-    Math.pow(10, -(n: Double) / 10)
+    Math.pow(10D, -(n: Double) / 10D)
 
   final
   def successProbability(n: Score): Prob =


### PR DESCRIPTION
Current situation: we have a 16MB ballast added to every loquat we launch.

```
> dependencyStats
...
[info]    TotSize    JarSize #TDe #Dep Module
[info]  17.207 MB ------- MB    7    2 ohnosequences:fastarious_2.12:0.11.0-3-g2f9ef1d-SNAPSHOT
[info]  16.688 MB   7.674 MB    5    3 org.typelevel:spire_2.12:0.14.1
[info]   9.015 MB   0.073 MB    4    2 org.typelevel:spire-macros_2.12:0.14.1
[info]   5.340 MB   1.098 MB    1    1 org.typelevel:algebra_2.12:0.7.0
[info]   4.242 MB   4.242 MB    0    0 org.typelevel:cats-kernel_2.12:0.9.0
[info]   3.602 MB   0.034 MB    1    1 org.typelevel:machinist_2.12:0.6.1
[info]   3.568 MB   3.568 MB    0    0 org.scala-lang:scala-reflect:2.12.3
[info]   0.519 MB   0.519 MB    0    0 ohnosequences:cosas_2.12:0.9.0
[info]
[info] Columns are
[info]  - Jar-Size including dependencies
[info]  - Jar-Size
[info]  - Number of transitive dependencies
[info]  - Number of direct dependencies
[info]  - ModuleID
```

Spire is a great library, but it's heavy, brings its macros/cats/machinists/scala-reflect dependencies, while we use **only 2 little things** from it:

- `log(10)`
- `fpow`

And as I see from the implementation for `Double`, it's just using `java.lang.Math`:

https://github.com/non/spire/blob/b5952220567830a7817aa37109109b4dbc9ddb83/core/shared/src/main/scala/spire/std/double.scala#L78

https://github.com/non/spire/blob/b5952220567830a7817aa37109109b4dbc9ddb83/core/shared/src/main/scala/spire/std/double.scala#L87
