### PR TITLE
NCBI Headers redesign

### DIFF
--- a/src/main/scala/ncbiHeaders.scala
+++ b/src/main/scala/ncbiHeaders.scala
@@ -59,13 +59,15 @@ case object ncbiHeaders {
   ) {
 
     // NOTE: the order is important
-    override def toString: String = Seq[Option[AnyNcbiID]](
-      Some(id),
-      lcl,
-      gb,
-      gi,
-      name
-    ).flatten.mkString("|")
+    override def toString: String = {
+      Seq[Option[AnyNcbiID]](
+        Some(id),
+        lcl,
+        gb,
+        gi
+      ).flatten.mkString("|") +
+      name.getOrElse("").toString
+    }
 
     // TODO
     // def asFastaHeader: fasta.Header = ???

--- a/src/test/scala/NcbiHeadersTests.scala
+++ b/src/test/scala/NcbiHeadersTests.scala
@@ -21,35 +21,15 @@ class NcbiHeadersTests extends FunSuite {
     Some(Name("cosas de la vida"))
   )
 
-  ignore("can construct a header string from an ncbi record value") {
+  test("can serialize") {
 
-    // val a1 = randomIds.asFastaHeader.value.toString
-    // assert { a1 == ">1AC3438D|lcl|db.rna16s|gb|A3CFTC4.4|X4CC8HG|gi|21312324 A really interesting sequence hola hola" }
-    //
-    // assert {
-    //   someMissingFields.asFastaHeader == (fasta.header := FastaHeader("1AC3438D|gb|A3CFTC4.4|X4CC8HG cosas de la vida"))
-    // }
+    assert { randomIds.toString ==
+      "1AC3438D|lcl|db.rna16s|gb|A3CFTC4.4|X4CC8HG|gi|21312324 A really interesting sequence hola hola"
+    }
+
+    assert { someMissingFields.toString ==
+      "1AC3438D|gb|A3CFTC4.4|X4CC8HG cosas de la vida"
+    }
   }
 
-  ignore("ncbi ids example use") {
-
-    // use the ids before and the sequence, Note the ugly seq etc
-    val seq = """
-    ATCCGTCCGTCCTGCGTCAAACGTCTGACCCACGTTTGTCATCATC
-    ATCCACGA
-    TTTCACAACAGTGTCAACTGACCCCCCCCCCCCCCCCCCCCCCCCCCC
-    CCCTACATATAATATATATATACCCGA
-    CCCCCTTCTACACTCCCCCCCCCCCACATGGTCATAC
-    ACACACCCCCCCCCCCCCC
-    AACT
-    ACACACCCCCCCC
-    TTTTCTCTCCCCCTTTTTTTT
-    """
-
-    // val fa = FASTA(
-    //   randomIds.asFastaHeader       ::
-    //   sequence(FastaSequence(seq))  ::
-    //   *[AnyDenotation]
-    // )
-  }
 }

--- a/src/test/scala/NcbiHeadersTests.scala
+++ b/src/test/scala/NcbiHeadersTests.scala
@@ -1,28 +1,24 @@
 package ohnosequences.fastarious.test
 
 import org.scalatest.FunSuite
-
-import ohnosequences.cosas._, types._, klists._
 import ohnosequences.fastarious._, ncbiHeaders._
 
 class NcbiHeadersTests extends FunSuite {
 
-  val randomIds = ncbiHeader(
-    id("1AC3438D")                                        ::
-    lcl(Some("db.rna16s"))                                ::
-    gb(Some(accession("A3CFTC4.4", "X4CC8HG")))           ::
-    gi(Some(21312324))                                    ::
-    name(Some("A really interesting sequence hola hola")) ::
-    *[AnyDenotation]
+  val randomIds = NcbiHeader(
+    ID("1AC3438D"),
+    Some(LCL("db.rna16s")),
+    Some(GB(Accession("A3CFTC4.4", "X4CC8HG"))),
+    Some(GI(21312324)),
+    Some(Name("A really interesting sequence hola hola"))
   )
 
-  val someMissingFields = ncbiHeader(
-    id("1AC3438D")                              ::
-    lcl(None)                                   ::
-    gb(Some(accession("A3CFTC4.4", "X4CC8HG"))) ::
-    gi(None)                                    ::
-    name(Some("cosas de la vida"))              ::
-    *[AnyDenotation]
+  val someMissingFields = NcbiHeader(
+    ID("1AC3438D"),
+    None,
+    Some(GB(Accession("A3CFTC4.4", "X4CC8HG"))),
+    None,
+    Some(Name("cosas de la vida"))
   )
 
   ignore("can construct a header string from an ncbi record value") {


### PR DESCRIPTION
After #24 and #25 (same as #38) the only code using cosas is `ncbiHeaders` and it is not essential there. If we apply the same redesign to this part as we did for fasta and fastq (i.e. using case classes instead of cosas-records), we can remove cosas dependency completely. It doesn't add much weight right now, but it's always easier to maintain and update with less dependencies.
